### PR TITLE
Update d3.values() method

### DIFF
--- a/src/values.js
+++ b/src/values.js
@@ -1,5 +1,8 @@
 export default function(map) {
-  var values = [];
-  for (var key in map) values.push(map[key]);
+  var values = [],
+      keys = Object.keys(map),
+      i = 0,
+      ln = keys.length;
+  for (; i < ln; ++i) values.push(map[keys[i]]);
   return values;
 }


### PR DESCRIPTION
The previous version of `d3.values()` method returns the property values of an object including the prototype chain.
But now it will return only own property values.