### PR TITLE
Allow array to be returned from key function to put item into multiple collections

### DIFF
--- a/src/nest.js
+++ b/src/nest.js
@@ -22,12 +22,18 @@ export default function() {
         values,
         result = createResult();
 
-    while (++i < n) {
-      if (values = valuesByKey.get(keyValue = key(value = array[i]) + "")) {
+    function pushKey(keyValue) {
+      if (values = valuesByKey.get(keyValue + "")) {
         values.push(value);
       } else {
         valuesByKey.set(keyValue, [value]);
       }
+    }
+
+    while (++i < n) {
+      keyValue = key(value = array[i]);
+      if (Array.isArray(keyValue)) keyValue.map(pushKey)
+      else pushKey(keyValue);
     }
 
     valuesByKey.each(function(values, key) {
@@ -69,9 +75,5 @@ function createMap() {
 }
 
 function setMap(map, key, value) {
-  if (Array.isArray(key)) {
-    key.forEach(function() { return map.set(key, value) });
-  } else {
-    map.set(key, value);
-  }
+  map.set(key, value);
 }

--- a/src/nest.js
+++ b/src/nest.js
@@ -69,5 +69,9 @@ function createMap() {
 }
 
 function setMap(map, key, value) {
-  map.set(key, value);
+  if (Array.isArray(key)) {
+    key.forEach(function() { return map.set(key, value) });
+  } else {
+    map.set(key, value);
+  }
 }

--- a/test/nest-test.js
+++ b/test/nest-test.js
@@ -42,6 +42,14 @@ tape("nest.key(key) coerces key values to strings", function(test) {
   test.end();
 });
 
+tape("nest.key(key) puts into mutiple collections when key returns an array", function(test) {
+  var nest = d3.nest().key(function(d) { return d.key }).sortKeys(d3.ascending),
+      a = {key: [1, 2]},
+      b = {key: 1};
+  test.deepEqual(nest.entries([a, b]), [{key: "1", values: [a, b]}, { key: "2", values: [a] }]);
+  test.end();
+});
+
 tape("nest.key(key1).key(key2).entries(array) returns entries for each distinct key set, with values in input order", function(test) {
   var nest = d3.nest().key(function(d) { return d.foo; }).sortKeys(d3.ascending).key(function(d) { return d.bar; }).sortKeys(d3.ascending),
       a = {foo: 1, bar: "a"},


### PR DESCRIPTION
With the current implementation, it's only possible to index items by a single value returned from key function. There is no obvious way to arrange items into multiple collections. This PR allows to return an array of keys from key function, the items in the array will be treated as keys for this item.