### PR TITLE
Added prepare script to tell npm to build on local installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/d3/d3-collection.git"
   },
   "scripts": {
+    "prepare": "npm run prepublish",
     "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -n d3 -o build/d3-collection.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs -b beautify=false,preamble=\"'$(preamble)'\" build/d3-collection.js -c -m -o build/d3-collection.min.js",


### PR DESCRIPTION
Added prepare script that builds the `build` folder. `prepare` makes it possible to install this package from github. npm will automatically run `prepare` script when installing locally from github. 

Here is what [npm documentation](https://docs.npmjs.com/misc/scripts) says:
> prepare: Run both BEFORE the package is packed and published, and on local npm install without any arguments (See below).