### PR TITLE
Add custom factory support for nest

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ var entries = d3.nest()
 
 Note that this only affects the result of [*nest*.entries](#nest_entries); the order of keys returned by [*nest*.map](#nest_map) and [*nest*.object](#nest_object) is always undefined, regardless of comparator.
 
+<a name="nest_factory" href="#nest_factory">#</a> <i>nest</i>.<b>factory</b>(<i>function</i>) [<>](https://github.com/d3/d3-collection/blob/master/src/nest.js#L8 "Source")
+
+Specifies the custom factory function to use when creating tree nodes.
+
 <a name="nest_sortValues" href="#nest_sortValues">#</a> <i>nest</i>.<b>sortValues</b>(<i>comparator</i>) [<>](https://github.com/d3/d3-collection/blob/master/src/nest.js#L6 "Source")
 
 Sorts leaf elements using the specified *comparator* function, such as [d3.ascending](https://github.com/d3/d3-array#ascending) or [d3.descending](https://github.com/d3/d3-array#descending). This is roughly equivalent to sorting the input array before applying the nest operator; however it is typically more efficient as the size of each group is smaller. If no value comparator is specified, elements will be returned in the order they appeared in the input array. This applies to [*nest*.map](#nest_map), [*nest*.entries](#nest_entries) and [*nest*.object](#nest_object).

--- a/src/nest.js
+++ b/src/nest.js
@@ -5,6 +5,7 @@ export default function() {
       sortKeys = [],
       sortValues,
       rollup,
+      factory,
       nest;
 
   function apply(array, depth, createResult, setResult) {
@@ -41,7 +42,13 @@ export default function() {
     if (++depth > keys.length) return map;
     var array, sortKey = sortKeys[depth - 1];
     if (rollup != null && depth >= keys.length) array = map.entries();
-    else array = [], map.each(function(v, k) { array.push({key: k, values: entries(v, depth)}); });
+    else {
+      array = [];
+      map.each(function (v, k) {
+        var values = entries(v, depth);
+        array.push(factory ? factory(k, values) : { key: k, values: values });
+      });
+    }
     return sortKey != null ? array.sort(function(a, b) { return sortKey(a.key, b.key); }) : array;
   }
 
@@ -52,7 +59,8 @@ export default function() {
     key: function(d) { keys.push(d); return nest; },
     sortKeys: function(order) { sortKeys[keys.length - 1] = order; return nest; },
     sortValues: function(order) { sortValues = order; return nest; },
-    rollup: function(f) { rollup = f; return nest; }
+    rollup: function(f) { rollup = f; return nest; },
+    factory: function(f) { factory = f; return nest; },
   };
 }
 

--- a/test/nest-test.js
+++ b/test/nest-test.js
@@ -170,3 +170,12 @@ tape("nest.key(key).rollup(rollup).map(array) aggregates values per key using th
   test.deepEqual(d3.nest().key(function(d) { return d.foo; }).rollup(function(values) { return values.length; }).map([a, b, c]), d3.map({1: 2, 2: 1}));
   test.end();
 });
+
+tape("nest.factory(f).entries(array) returns entries created by custom factory", function(test) {
+  var nest = d3.nest().factory(function(k, v) { return {k:k, v:v}; }).key(function(d) { return d.foo; }),
+    a = {foo: 1},
+    b = {foo: 1},
+    c = {foo: 2};
+  test.deepEqual(nest.entries([a, b, c]), [{k: "1", v: [a, b]}, {k: "2", v: [c]}]);
+  test.end();
+});


### PR DESCRIPTION
A more generic approach to customize new node creation using a factory method.

This allows (for example) to create sub-aggregations for each node of all sub-nodes without doing a complex postprocessing (no need to implement tree iteration)

```js
d3.nest().factory((k, v) => (
  {
    key: k,
    values: v,
    sum: v.reduce((acc, vv) => acc + vv.sum, 0)
  }
).key( v => v.foo ).entries([
  {foo: 'a', sum: 10},
  {foo: 'b', sum: 15},
  ...
]).
```